### PR TITLE
🔧 モバイルサイドバー目次の視認性向上

### DIFF
--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -213,6 +213,33 @@
             background-color: var(--background-secondary) !important;
         }
         
+        /* Mobile sidebar visibility enhancement */
+        .book-sidebar {
+            background-color: var(--background-secondary) !important;
+            box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15) !important;
+        }
+        
+        .book-sidebar * {
+            opacity: 1 !important;
+        }
+        
+        .book-sidebar .book-title,
+        .book-sidebar .toc-section-title,
+        .book-sidebar .toc-link {
+            color: var(--text-primary) !important;
+            opacity: 1 !important;
+        }
+        
+        .book-sidebar .toc-link {
+            color: var(--text-secondary) !important;
+        }
+        
+        .book-sidebar .toc-link:hover,
+        .book-sidebar .toc-link.active {
+            background-color: var(--accent-color) !important;
+            color: white !important;
+        }
+        
         /* Production overlay */
         .sidebar-toggle-checkbox:checked ~ .book-sidebar-overlay {
             opacity: 1 !important;

--- a/assets/css/mobile-responsive.css
+++ b/assets/css/mobile-responsive.css
@@ -315,13 +315,41 @@ a:hover {
     left: 0;
     width: 280px; /* Fixed width for mobile */
     height: calc(100vh - var(--header-height));
-    background-color: var(--background-secondary);
+    background-color: var(--background-secondary) !important;
     border-right: 1px solid var(--border-color);
     padding: var(--space-lg);
     overflow-y: auto;
     z-index: 1000;
     transform: translateX(-100%);
     transition: transform 0.3s ease-in-out;
+    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
+  }
+  
+  /* Mobile sidebar content visibility */
+  .book-sidebar * {
+    color: var(--text-primary) !important;
+    opacity: 1 !important;
+  }
+  
+  /* Mobile sidebar links */
+  .book-sidebar .toc-link {
+    color: var(--text-secondary) !important;
+    background-color: transparent !important;
+    opacity: 1 !important;
+  }
+  
+  .book-sidebar .toc-link:hover,
+  .book-sidebar .toc-link.active {
+    background-color: var(--accent-color) !important;
+    color: white !important;
+    opacity: 1 !important;
+  }
+  
+  /* Mobile sidebar headings */
+  .book-sidebar .book-title,
+  .book-sidebar .toc-section-title {
+    color: var(--text-primary) !important;
+    opacity: 1 !important;
   }
 
   /* Show sidebar when checkbox is checked */


### PR DESCRIPTION
## 🔧 問題解決: モバイルサイドバーの目次透明度問題

モバイルでハンバーガーメニューを開いた時に目次が透明で見づらい問題を解決しました。

## 🐛 発生していた問題

### 症状
- **モバイルサイドバーが透明**: 背景が透けて見える
- **目次テキストが薄い**: 文字が読みづらい
- **視認性が悪い**: ユーザビリティの大幅低下

### 根本原因
1. **デスクトップCSS設定の影響**: `background-color: transparent` がモバイルに継承
2. **opacity継承問題**: 子要素の透明度が意図せず適用
3. **CSS優先度問題**: モバイル用設定が上書きされる

## 🛠️ 解決策

### 1. モバイルサイドバー背景の強制設定
```css
.book-sidebar {
  background-color: var(--background-secondary) \!important;
  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15); /* 立体感追加 */
}
```

### 2. 全子要素の透明度完全リセット
```css
.book-sidebar * {
  color: var(--text-primary) \!important;
  opacity: 1 \!important; /* 透明度を完全に解除 */
}
```

### 3. 目次リンクの視認性強化
```css
/* 通常状態 */
.book-sidebar .toc-link {
  color: var(--text-secondary) \!important;
  background-color: transparent \!important;
  opacity: 1 \!important;
}

/* ホバー・アクティブ状態 */
.book-sidebar .toc-link:hover,
.book-sidebar .toc-link.active {
  background-color: var(--accent-color) \!important;
  color: white \!important;
  opacity: 1 \!important;
}
```

### 4. 見出しタイトルの明確化
```css
.book-sidebar .book-title,
.book-sidebar .toc-section-title {
  color: var(--text-primary) \!important;
  opacity: 1 \!important;
}
```

## 🎯 実装戦略

### CSS実装箇所
1. **mobile-responsive.css**: メディアクエリ内での基本設定
2. **book.html インライン**: 最高優先度での確実な適用

### 優先度制御
- `\!important` による確実な適用
- インラインCSSによる最高優先度確保
- デスクトップ設定の完全上書き

## ✨ 改善効果

### 視覚的改善
- 🎨 **背景明確化**: サイドバー背景がはっきり表示
- 📝 **文字鮮明化**: 目次テキストがクリアに見える
- 🎯 **ホバー効果**: リンクの反応が視覚的に分かりやすい
- 💫 **立体感**: box-shadowで浮遊感を演出

### ユーザビリティ向上
- 📱 **モバイル最適**: スマホでの操作性大幅向上
- 🔍 **視認性**: 薄暗い環境でも読みやすい
- 👆 **タッチ操作**: 目次項目の選択が確実に

### テーマ対応
- 🌓 **ライト/ダーク**: 両テーマで適切な色表示
- 🎨 **CSS変数活用**: テーマ切り替え時の自動調整
- 🔄 **一貫性**: デスクトップ版と統一感維持

## 🧪 確認項目

### モバイル表示確認
- [ ] ハンバーガーメニューをタップして開く
- [ ] サイドバー背景が明確に表示される
- [ ] 目次項目のテキストがはっきり見える
- [ ] 「📚 この本について」等の見出しが鮮明

### インタラクション確認
- [ ] 目次リンクのホバー効果が動作
- [ ] アクティブページのハイライト表示
- [ ] オーバーレイタップでサイドバーが閉じる

### テーマ切り替え確認
- [ ] ライトテーマでの適切な表示
- [ ] ダークテーマでの適切な表示
- [ ] テーマ切り替え時の色の正常変更

---

**🎯 モバイルサイドバーの視認性が大幅に改善されます。**

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>