### PR TITLE
Fix mobile sidebar transparency for all themes

### DIFF
--- a/assets/css/mobile-responsive.css
+++ b/assets/css/mobile-responsive.css
@@ -323,33 +323,82 @@ a:hover {
     transform: translateX(-100%);
     transition: transform 0.3s ease-in-out;
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
+    opacity: 1 !important;
+  }
+
+  /* Force background for both light and dark mode */
+  .book-sidebar {
+    background: var(--background-secondary) !important;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .book-sidebar {
+      background: #1f2937 !important;
+    }
+  }
+
+  @media (prefers-color-scheme: light) {
+    .book-sidebar {
+      background: #f9fafb !important;
+    }
   }
   
-  /* Mobile sidebar content visibility */
+  /* Mobile sidebar content visibility - ensure all text is visible */
   .book-sidebar * {
-    color: var(--text-primary) !important;
     opacity: 1 !important;
   }
-  
-  /* Mobile sidebar links */
+
+  /* Mobile sidebar text colors for both themes */
+  .book-sidebar *,
+  .book-sidebar .book-title,
+  .book-sidebar .toc-section-title,
   .book-sidebar .toc-link {
-    color: var(--text-secondary) !important;
-    background-color: transparent !important;
-    opacity: 1 !important;
+    color: var(--text-primary) !important;
+  }
+
+  /* Force colors for dark mode */
+  @media (prefers-color-scheme: dark) {
+    .book-sidebar *,
+    .book-sidebar .book-title,
+    .book-sidebar .toc-section-title,
+    .book-sidebar .toc-link {
+      color: #f9fafb !important;
+    }
+  }
+
+  /* Force colors for light mode */  
+  @media (prefers-color-scheme: light) {
+    .book-sidebar *,
+    .book-sidebar .book-title,
+    .book-sidebar .toc-section-title,
+    .book-sidebar .toc-link {
+      color: #111827 !important;
+    }
   }
   
+  /* Mobile sidebar links - hover and active states */
   .book-sidebar .toc-link:hover,
   .book-sidebar .toc-link.active {
     background-color: var(--accent-color) !important;
     color: white !important;
     opacity: 1 !important;
   }
-  
-  /* Mobile sidebar headings */
-  .book-sidebar .book-title,
-  .book-sidebar .toc-section-title {
-    color: var(--text-primary) !important;
-    opacity: 1 !important;
+
+  /* Force hover/active colors for both themes */
+  @media (prefers-color-scheme: dark) {
+    .book-sidebar .toc-link:hover,
+    .book-sidebar .toc-link.active {
+      background-color: #3b82f6 !important;
+      color: white !important;
+    }
+  }
+
+  @media (prefers-color-scheme: light) {
+    .book-sidebar .toc-link:hover,
+    .book-sidebar .toc-link.active {
+      background-color: #3b82f6 !important;
+      color: white !important;
+    }
   }
 
   /* Show sidebar when checkbox is checked */


### PR DESCRIPTION
## Summary
- モバイルサイドバーの透明度問題を修正
- ダークモード・ライトモード両方で完全に不透明な背景を強制設定
- 全てのテキストが視認可能になるよう色コントラストを改善

## Changes
- `.book-sidebar`に明示的な背景色設定を追加（theme-specific）
- 全てのサイドバー内テキストに強制的な色設定
- hover/activeステートの色も両テーマに対応

## Test Results
- ダークモード端末での視認性問題解決
- ライトモードでの画面幅縮小時の問題解決  
- 背景が透明で文字だけが表示される問題を完全解決

🤖 Generated with [Claude Code](https://claude.ai/code)