### PR TITLE
Fix CSS-only mobile sidebar transparency and visibility

### DIFF
--- a/assets/css/mobile-responsive.css
+++ b/assets/css/mobile-responsive.css
@@ -401,9 +401,47 @@ a:hover {
     }
   }
 
-  /* Show sidebar when checkbox is checked */
+  /* Show sidebar when checkbox is checked - CRITICAL FIX */
   .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
-    transform: translateX(0);
+    transform: translateX(0) !important;
+    background: #ffffff !important;
+    background-color: #ffffff !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+  }
+
+  /* Dark mode sidebar when open */
+  @media (prefers-color-scheme: dark) {
+    .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
+      background: #1f2937 !important;
+      background-color: #1f2937 !important;
+    }
+  }
+
+  /* Force sidebar content visibility when open */
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar * {
+    opacity: 1 !important;
+  }
+
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .book-title,
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-section-title {
+    color: #111827 !important;
+  }
+
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link {
+    color: #6b7280 !important;
+  }
+
+  /* Dark mode text when sidebar is open */
+  @media (prefers-color-scheme: dark) {
+    .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .book-title,
+    .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-section-title {
+      color: #f9fafb !important;
+    }
+
+    .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link {
+      color: #d1d5db !important;
+    }
   }
 
   /* Overlay for mobile */
@@ -420,10 +458,11 @@ a:hover {
     transition: opacity 0.3s ease, visibility 0.3s ease;
   }
 
-  /* Show overlay when checkbox is checked */
+  /* Show overlay when checkbox is checked - CRITICAL FIX */
   .sidebar-toggle-checkbox:checked ~ .book-sidebar-overlay {
-    opacity: 1;
-    visibility: visible;
+    opacity: 1 !important;
+    visibility: visible !important;
+    background-color: rgba(0, 0, 0, 0.5) !important;
   }
 
   /* Show hamburger menu on mobile */


### PR DESCRIPTION
## CSS-only モバイルサイドバーの完全修正

### 問題の根本原因
- インラインCSSが外部CSSファイルを上書きしていた
- `:checked`状態での明示的な背景色・文字色設定が不足
- サイドバーが開いた時の視認性が確保されていなかった

### 修正内容
1. **強制的な背景色設定**
   - `:checked`状態で明示的に白/グレー背景を強制
   - `\!important`でインラインCSSを上書き

2. **テキスト視認性の確保**
   - サイドバーが開いた時の全テキストを強制的に可視化
   - ライトモード: 濃い色文字
   - ダークモード: 明るい色文字

3. **オーバーレイの確実な表示**
   - `:checked`時のオーバーレイも`\!important`で強制

### 技術的改善
- CSS優先度の問題を根本解決
- ハードコード色で確実な表示を実現
- 全ての状態で透明度問題を排除

🤖 Generated with [Claude Code](https://claude.ai/code)