### PR TITLE
FINAL FIX: Make mobile sidebar background transparent unless open

### DIFF
--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -213,53 +213,62 @@
             background-color: var(--background-secondary) !important;
         }
         
-        /* Mobile sidebar visibility enhancement - CRITICAL FIX */
+        /* Mobile sidebar - TRANSPARENT by default, background ONLY when open */
         @media (max-width: 767px) {
             .book-sidebar {
-                background: #ffffff !important;
-                background-color: #ffffff !important;
-                box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15) !important;
+                background: transparent !important;
+                background-color: transparent !important;
+                box-shadow: none !important;
                 opacity: 1 !important;
             }
             
-            /* Dark mode specific background */
+            /* Background ONLY when sidebar is checked/open */
+            .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
+                background: #ffffff !important;
+                background-color: #ffffff !important;
+                box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15) !important;
+            }
+            
+            /* Dark mode background ONLY when open */
             @media (prefers-color-scheme: dark) {
-                .book-sidebar {
+                .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
                     background: #1f2937 !important;
                     background-color: #1f2937 !important;
                 }
             }
             
-            .book-sidebar * {
+            /* Text styling ONLY when sidebar is open */
+            .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar * {
                 opacity: 1 !important;
             }
             
-            .book-sidebar .book-title,
-            .book-sidebar .toc-section-title {
+            .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .book-title,
+            .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-section-title {
                 color: #111827 !important;
                 opacity: 1 !important;
             }
             
-            .book-sidebar .toc-link {
+            .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link {
                 color: #6b7280 !important;
                 opacity: 1 !important;
                 background: transparent !important;
             }
             
-            /* Dark mode text colors */
+            /* Dark mode text colors ONLY when open */
             @media (prefers-color-scheme: dark) {
-                .book-sidebar .book-title,
-                .book-sidebar .toc-section-title {
+                .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .book-title,
+                .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-section-title {
                     color: #f9fafb !important;
                 }
                 
-                .book-sidebar .toc-link {
+                .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link {
                     color: #d1d5db !important;
                 }
             }
             
-            .book-sidebar .toc-link:hover,
-            .book-sidebar .toc-link.active {
+            /* Hover/active states ONLY when sidebar is open */
+            .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link:hover,
+            .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link.active {
                 background-color: #3b82f6 !important;
                 color: #ffffff !important;
             }


### PR DESCRIPTION
## 最終修正：モバイルサイドバー透明度問題の完全解決

### 根本問題
`_layouts/book.html`のインラインCSS内で：
```css
@media (max-width: 767px) {
    .book-sidebar {
        background: #ffffff \!important; /* 常に背景色が設定 */
    }
}
```
→ サイドバーの開閉状態に関係なく、常に背景色が適用されていた

### 完全修正

#### 1. デフォルト状態（閉じた状態）
```css
.book-sidebar {
    background: transparent \!important; /* 透明背景 */
    box-shadow: none \!important;        /* シャドウなし */
}
```

#### 2. 開いた状態（:checked）のみ
```css  
.sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
    background: #ffffff \!important;     /* ライトモード白背景 */
    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15) \!important;
}

@media (prefers-color-scheme: dark) {
    .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
        background: #1f2937 \!important; /* ダークモードグレー背景 */
    }
}
```

### 結果
✅ 閉じた状態：完全に透明  
✅ 開いた状態：不透明背景  
✅ 選択項目：青背景正常動作  
✅ ダークモード対応

🤖 Generated with [Claude Code](https://claude.ai/code)