### PR TITLE
Fix sidebar transparency regression after cleanup

### DIFF
--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -213,11 +213,17 @@
             background-color: var(--background-secondary) !important;
         }
         
-        /* Critical inline CSS override - minimal necessary fixes only */
+        /* Critical inline CSS override - transparent by default, solid when open */
         @media (max-width: 767px) {
             .book-sidebar {
                 background: transparent !important;
                 box-shadow: none !important;
+            }
+            
+            /* Override when sidebar is open */
+            .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
+                background: var(--background-secondary) !important;
+                box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15) !important;
             }
         }
         


### PR DESCRIPTION
## 🚨 緊急修正: CSS整理後のサイドバー透明度問題再発

### 問題
PR#46のCSS整理により、モバイルサイドバーが開いた時も透明のままになる問題が再発。

### 根本原因
```css  
/* インラインCSS */
@media (max-width: 767px) {
    .book-sidebar {
        background: transparent \!important; /* これが常に適用される */
        box-shadow: none \!important;
    }
}
```
→ `:checked`状態でも`\!important`により透明背景が強制される

### 修正内容
```css
@media (max-width: 767px) {
    .book-sidebar {
        background: transparent \!important;
        box-shadow: none \!important;
    }
    
    /* 追加: :checked状態での上書き */
    .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
        background: var(--background-secondary) \!important;
        box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15) \!important;
    }
}
```

### 結果
- ✅ 閉じた状態: 透明背景
- ✅ 開いた状態: 不透明背景  
- ✅ テーマ対応: CSS変数で自動切替
- ✅ 最小限修正: 必要な7行のみ追加

---

**🎯 モバイルサイドバーの透明度問題を完全解決**

🤖 Generated with [Claude Code](https://claude.ai/code)