### PR TITLE
Fix: イシュー#65「目視チェック 1章～7章」の視覚的問題を修正

### DIFF
--- a/assets/diagrams/chapter3/figure3-12-atcoder-first-submission.svg
+++ b/assets/diagrams/chapter3/figure3-12-atcoder-first-submission.svg
@@ -92,7 +92,7 @@
   </g>
   
   <!-- No Branch -->
-  <path d="M350 450 L250 450 L250 300 L310 300" class="arrow" marker-end="url(#arrow)"/>
+  <path d="M350 450 L250 450 L250 300 L320 300" class="arrow" marker-end="url(#arrow)"/>
   <text x="280" y="445" style="font: 600 12px Inter, sans-serif; fill: #EF4444;">修正</text>
   
   <!-- Yes Branch -->
@@ -137,8 +137,8 @@
   
   <!-- Flow arrows for side steps -->
   <path d="M400 530 L270 530 L270 390 L260 390" class="arrow" marker-end="url(#arrow)"/>
-  <path d="M180 360 L180 330" class="arrow" marker-end="url(#arrow)"/>
-  <path d="M180 260 L180 230" class="arrow" marker-end="url(#arrow)"/>
+  <path d="M180 360 L180 320" class="arrow" marker-end="url(#arrow)"/>
+  <path d="M180 260 L180 220" class="arrow" marker-end="url(#arrow)"/>
   
   <!-- Side Information Boxes -->
   <!-- Tips Box -->

--- a/assets/diagrams/chapter3/figure3-3-python-future-applications.svg
+++ b/assets/diagrams/chapter3/figure3-3-python-future-applications.svg
@@ -138,8 +138,8 @@
   </g>
   
   <!-- Connection Lines -->
-  <path d="M160 340 Q200 320 240 330" class="connection-line"/>
-  <path d="M400 340 Q440 320 480 330" class="connection-line"/>
+  <path d="M160 340 L240 330" class="connection-line"/>
+  <path d="M400 340 L480 330" class="connection-line"/>
   
   <!-- Bottom Summary -->
   <g id="summary">

--- a/assets/diagrams/chapter3/figure3-9-thonny-features.svg
+++ b/assets/diagrams/chapter3/figure3-9-thonny-features.svg
@@ -100,10 +100,10 @@
   </g>
   
   <!-- Connection lines to center -->
-  <path d="M230 100 Q315 125 260 150" class="connector"/>
-  <path d="M570 100 Q485 125 540 150" class="connector"/>
-  <path d="M230 300 Q315 275 260 150" class="connector"/>
-  <path d="M570 300 Q485 275 540 150" class="connector"/>
+  <path d="M230 100 L260 150" class="connector"/>
+  <path d="M570 100 L540 150" class="connector"/>
+  <path d="M230 300 L260 150" class="connector"/>
+  <path d="M570 300 L540 150" class="connector"/>
   
   <!-- Benefits Section -->
   <g id="benefits">

--- a/assets/diagrams/chapter4/figure4-17-print-function-complete-usage.svg
+++ b/assets/diagrams/chapter4/figure4-17-print-function-complete-usage.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 800 700" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 800 750" xmlns="http://www.w3.org/2000/svg">
   <title>図4-17：print()関数の完全活用</title>
   <desc>print()関数の様々なパラメータと使用方法を包括的に説明する図</desc>
   

--- a/assets/diagrams/chapter4/figure4-2-general-vs-competitive-programming.svg
+++ b/assets/diagrams/chapter4/figure4-2-general-vs-competitive-programming.svg
@@ -147,8 +147,8 @@
   </g>
   
   <!-- Bottom Example -->
-  <g transform="translate(200, 560)">
-    <text x="0" y="0" style="font: 600 14px Inter, sans-serif; fill: #374151;">
+  <g transform="translate(100, 570)">
+    <text x="300" y="0" text-anchor="middle" style="font: 600 13px Inter, sans-serif; fill: #374151;">
       📚 この違いを理解することで、競技プログラミング特有の入出力パターンが身につく
     </text>
   </g>

--- a/assets/diagrams/chapter4/figure4-9-map-function-conversion.svg
+++ b/assets/diagrams/chapter4/figure4-9-map-function-conversion.svg
@@ -26,8 +26,8 @@
       <path d="M0,0 L0,6 L12,3 z" fill="#3B82F6"/>
     </marker>
     
-    <marker id="transform-arrow" markerWidth="16" markerHeight="16" refX="14" refY="4" orient="auto">
-      <path d="M0,0 L0,8 L16,4 z" fill="#10B981"/>
+    <marker id="transform-arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L10,3 z" fill="#10B981"/>
     </marker>
   </defs>
   

--- a/src/chapter-abc-problems/index.md
+++ b/src/chapter-abc-problems/index.md
@@ -30,7 +30,7 @@ order: 7
 
 ### A問題の出題パターン分析
 
-![ABC A問題の典型パターンと実装戦略を示す図表：四則演算、文字列操作、条件分岐、入出力処理の4つのパターンを頻度順で表示]({{ site.baseurl }}/images/figure7-2-abc-a-typical-patterns.svg)
+![ABC A問題の典型パターンと実装戦略を示す図表：四則演算、文字列操作、条件分岐、入出力処理の4つのパターンを頻度順で表示]({{ site.baseurl }}/assets/diagrams/chapter7/figure7-2-abc-a-problem-patterns.svg)
 
 ABC A問題は、以下の4つの典型パターンに分類できる：
 


### PR DESCRIPTION
## Summary
イシュー#65で報告された1章～7章の視覚的問題を修正しました。

## 修正内容

### SVG図表の修正
- **figure3-3**: 円弧の誤った塗りつぶしを修正（曲線接続ラインの arc フィル問題）
- **figure3-9**: 円弧の誤った塗りつぶしを修正（曲線接続ラインの arc フィル問題）  
- **figure3-12**: 矢印やオブジェクトの重なり問題を修正（複雑なフローチャートのレイアウト調整）
- **figure4-2**: 一番下の文の重なりを修正（位置調整と中央揃え）
- **figure4-9**: 緑矢印の終点△サイズを修正（16x16 → 10x10ピクセル）
- **figure4-17**: viewBox高さを拡張（700 → 750）で要素のはみ出しを防止

### パス参照の修正
- **Chapter 7.1**: A問題出題パターン分析図表の参照パスを修正
  - `/images/figure7-2-abc-a-typical-patterns.svg` → `/assets/diagrams/chapter7/figure7-2-abc-a-problem-patterns.svg`

## Test plan
- [x] 各修正対象の SVG ファイルが正常に表示されることを確認
- [x] 曲線パスの誤った塗りつぶし問題が解決されていることを確認
- [x] オブジェクトの重なりや配置問題が解決されていることを確認
- [x] 矢印のサイズが適切になっていることを確認
- [x] viewBox の拡張により要素がはみ出さないことを確認
- [x] パス参照が正しいファイルを指していることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)