### PR TITLE
Fix Chapter 6 stack implementation block layout issue

### DIFF
--- a/src/chapter-basic-data-structures/index.md
+++ b/src/chapter-basic-data-structures/index.md
@@ -669,8 +669,6 @@ order: 6
 
 ![図6-3：スタックとキューの活用]({{ site.baseurl }}/images/figure6-3-stack-queue-utilization.svg)
 
-```
-
 ### Pythonでのスタック実装
 
 ```


### PR DESCRIPTION
## Summary
This PR fixes a critical markdown structure issue in Chapter 6 where the "Pythonでのスタック実装" section and all subsequent content was incorrectly rendering inside a code block.

## Problem Identified
- Line 672: Stray code block marker (```) without proper opening
- Line 674: Section heading "### Pythonでのスタック実装" was trapped inside code block
- All content from this point onwards was displaying as code instead of formatted markdown

## Changes Made
- Removed the stray code block marker on line 672
- Restored proper section hierarchy for "### Pythonでのスタック実装"
- Fixed markdown structure to ensure subsequent sections display correctly

## Impact
- ✅ "Pythonでのスタック実装" section now displays as proper heading
- ✅ All subsequent content renders correctly outside code blocks
- ✅ Overall chapter layout and readability restored

## Test plan
- [x] Verify stack implementation section displays as proper heading
- [x] Confirm subsequent sections are not trapped in code blocks
- [x] Check overall markdown structure integrity

🤖 Generated with [Claude Code](https://claude.ai/code)