### PR TITLE
SEO: remove duplicate OG/Twitter meta (use jekyll-seo-tag)

### DIFF
--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -26,16 +26,7 @@
     <link rel="icon" type="image/x-icon" href="{{ '/assets/favicon.ico' | relative_url }}">
     <link rel="apple-touch-icon" href="{{ '/assets/apple-touch-icon.png' | relative_url }}">
     
-    <!-- Open Graph -->
-    <meta property="og:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
-    <meta property="og:description" content="{{ page.description | default: site.description | escape }}">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ page.url | absolute_url }}">
-    
-    <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
-    <meta name="twitter:description" content="{{ page.description | default: site.description | escape }}">
+    {%- comment -%} jekyll-seo-tag outputs Open Graph, Twitter, canonical, etc. {%- endcomment -%}
     
     <!-- Theme Detection Script -->
     <script>


### PR DESCRIPTION
Clean up duplicate meta tags. Rely on {% raw %}{% seo %}{% endraw %} to generate OG/Twitter/canonical.\nFixes #94.