### PR TITLE
Diagrams: Export Mermaid to SVG (ch8 3-stage flow)

### DIFF
--- a/.github/workflows/mermaid-export.yml
+++ b/.github/workflows/mermaid-export.yml
@@ -1,0 +1,31 @@
+name: Export Mermaid diagrams to SVG
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'assets/mermaid/**/*.mmd'
+      - '.github/workflows/mermaid-export.yml'
+  workflow_dispatch: {}
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: |
+          npm -g install @mermaid-js/mermaid-cli@10
+          mkdir -p assets/diagrams/generated
+          for f in $(find assets/mermaid -name '*.mmd'); do \
+            base=$(basename "$f" .mmd); \
+            mmdc -i "$f" -o "assets/diagrams/generated/${base}.svg" --backgroundColor white; \
+          done
+      - name: Commit generated SVG
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: 'assets/diagrams/generated/*.svg'
+          message: 'chore(diagrams): export Mermaid to SVG [skip ci]'
+          default_author: github_actions
+

--- a/assets/mermaid/ch8-3stage.mmd
+++ b/assets/mermaid/ch8-3stage.mmd
@@ -1,0 +1,6 @@
+flowchart LR
+  A[第1段階: 全体把握] --> B[第2段階: 詳細理解]
+  B --> C[第3段階: 実装準備]
+  A:::s A:::s; B:::s; C:::s
+  classDef s fill:#eef,stroke:#99c,color:#111;
+

--- a/src/chapter-problem-solving/index.md
+++ b/src/chapter-problem-solving/index.md
@@ -29,13 +29,10 @@ CC BY-NC-SA 4.0ライセンスの下で提供されます。
 
 【図8-1：問題文読解の3段階プロセス】
 
-```mermaid
-flowchart LR
-  A[第1段階: 全体把握] --> B[第2段階: 詳細理解]
-  B --> C[第3段階: 実装準備]
-  A:::s A:::s; B:::s; C:::s
-  classDef s fill:#eef,stroke:#99c,color:#111;
-```
+<figure>
+  <img src="{{ '/assets/diagrams/generated/ch8-3stage.svg' | relative_url }}" alt="図8-1：問題文読解の3段階プロセス">
+  <figcaption>図8-1：問題文読解の3段階プロセス</figcaption>
+</figure>
 
 {% capture s1a %}
 **目的**: 問題の全体像を掴む  


### PR DESCRIPTION
Adds assets/mermaid/ch8-3stage.mmd and GitHub Actions workflow to export *.mmd to SVG. Updates Chapter 8 to embed the generated SVG. Mermaid JS remains for other prototypes; final goal is SVG-only.