### PR TITLE
CI: fix link-check action tag (lychee-action@v1)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check links with lychee
-        uses: lycheeverse/lychee-action@v1.10.1
+        uses: lycheeverse/lychee-action@v1
         with:
           args: >
             --verbose
@@ -21,4 +21,3 @@ jobs:
             --max-concurrency 8
             https://ootakazuhiko.github.io/competitive_programming_book/
           fail: false
-


### PR DESCRIPTION
- lychee-action のタグ解決エラーにより失敗していたため、安定の @v1 を指定\n- これによりPR時のリンクチェックが復帰