### PR TITLE
Fix: Figures 4-11/12/13, 5-4, 6-3 render properly

### DIFF
--- a/src/chapter-basic-algorithms/index.md
+++ b/src/chapter-basic-algorithms/index.md
@@ -59,26 +59,28 @@ CC BY-NC-SA 4.0ライセンスの下で提供されます。
 
 【図5-4：数値の各桁分解プロセス】
 
-例：数値 1234 の各桁の和を求める
+<figure class="pseudocode">
+  <figcaption>各桁の和を求める（手続きの流れ）</figcaption>
+  <pre><code class="language-text">例：数値 1234 の各桁の和を求める
 
-Step 1: temp = 1234, digit_sum = 0  
-temp % 10 = 4（最下位桁） → digit_sum = 0 + 4 = 4 → temp = 123
+Step 1: temp = 1234, digit_sum = 0
+  temp % 10 = 4（最下位桁） → digit_sum = 4 → temp = 123
 
-Step 2: temp = 123, digit_sum = 4  
-temp % 10 = 3 → digit_sum = 7 → temp = 12
+Step 2: temp = 123, digit_sum = 4
+  temp % 10 = 3 → digit_sum = 7 → temp = 12
 
-Step 3: temp = 12, digit_sum = 7  
-temp % 10 = 2 → digit_sum = 9 → temp = 1
+Step 3: temp = 12, digit_sum = 7
+  temp % 10 = 2 → digit_sum = 9 → temp = 1
 
-Step 4: temp = 1, digit_sum = 9  
-temp % 10 = 1 → digit_sum = 10 → temp = 0
+Step 4: temp = 1, digit_sum = 9
+  temp % 10 = 1 → digit_sum = 10 → temp = 0
 
-Step 5: temp = 0 → ループ終了  
-結果: digit_sum = 10
-
-💡 重要な演算子  
-• % (mod): 余りを求める → 最下位桁の取得  
-• // (整数除算): 小数切り捨ての除算 → 最下位桁の除去
+Step 5: temp = 0 → ループ終了
+結果: digit_sum = 10</code></pre>
+  <figcaption>💡 重要な演算子</figcaption>
+  <pre><code class="language-text">• % (mod): 余りを求める → 最下位桁の取得
+• // (整数除算): 小数切り捨ての除算 → 最下位桁の除去</code></pre>
+</figure>
 
 ### より複雑な全探索の例
 

--- a/src/chapter-basic-data-structures/index.md
+++ b/src/chapter-basic-data-structures/index.md
@@ -91,32 +91,27 @@ print(numbers)  # [100, 33, 2]
 
 【図6-3：二次元リストの構造と活用法】
 
-📊 二次元リストの基本概念
-
-```python
-grid = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-```
-
-<div class="table-scroll">
-<table class="table-compact table-striped">
-  <thead>
-    <tr><th></th><th>列0</th><th>列1</th><th>列2</th></tr>
-  </thead>
-  <tbody>
-    <tr><th>行0</th><td>1</td><td>2</td><td>3</td></tr>
-    <tr><th>行1</th><td>4</td><td>5</td><td>6</td></tr>
-    <tr><th>行2</th><td>7</td><td>8</td><td>9</td></tr>
-  </tbody>
-</table>
-</div>
-
-アクセス方法:
-
-```python
-print(grid[0][0])  # 1
+<figure>
+  <figcaption>二次元リストの構造と活用法</figcaption>
+  <pre><code class="language-python">grid = [[1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9]]</code></pre>
+  <div class="table-scroll">
+  <table class="table-compact table-striped">
+    <thead>
+      <tr><th></th><th>列0</th><th>列1</th><th>列2</th></tr>
+    </thead>
+    <tbody>
+      <tr><th>行0</th><td>1</td><td>2</td><td>3</td></tr>
+      <tr><th>行1</th><td>4</td><td>5</td><td>6</td></tr>
+      <tr><th>行2</th><td>7</td><td>8</td><td>9</td></tr>
+    </tbody>
+  </table>
+  </div>
+  <pre><code class="language-python">print(grid[0][0])  # 1
 print(grid[1][2])  # 6
-print(grid[2][1])  # 8
-```
+print(grid[2][1])  # 8</code></pre>
+</figure>
 
 🏗️ 二次元リストの作成方法
 <figure class="pseudocode">

--- a/src/chapter-input-output/index.md
+++ b/src/chapter-input-output/index.md
@@ -291,6 +291,7 @@ for _ in range(n):        # N回繰り返し
 print(max(numbers))       # 最大値: 25
 print(sum(numbers))       # 合計: 48
 print(len(numbers))       # 個数: 3
+```
 </figure>
 
 ### リスト内包表記による効率化
@@ -310,6 +311,7 @@ n = int(input())
 numbers = []
 for _ in range(n):
     numbers.append(int(input()))
+```
 </figure>
 
 ✅ 内包表記（推奨）：
@@ -319,6 +321,7 @@ for _ in range(n):
 ```python
 n = int(input())
 numbers = [int(input()) for _ in range(n)]
+```
 </figure>
 
 さらなる応用例：
@@ -332,6 +335,7 @@ for _ in range(n):
     v = int(input())
     if v > 0:
         positive_nums.append(v)
+```
 </figure>
 
 <figure class="pseudocode">
@@ -341,6 +345,7 @@ for _ in range(n):
 n = int(input())
 points = [list(map(int, input().split())) for _ in range(n)]
 # 例: [[1, 2], [3, 4], [5, 6]]
+```
 </figure>
 
 💡 "_"（アンダースコア）の意味：
@@ -376,6 +381,7 @@ for _ in range(n):
 print(matrix[0][0])  # 1行1列目: 1
 print(matrix[1][2])  # 2行3列目: 7
 print(matrix[2][3])  # 3行4列目: 12
+```
 </figure>
 
 内包表記版：
@@ -385,6 +391,7 @@ print(matrix[2][3])  # 3行4列目: 12
 ```python
 n, m = map(int, input().split())
 matrix = [list(map(int, input().split())) for _ in range(n)]
+```
 </figure>
 
 実用例：
@@ -402,6 +409,7 @@ for row in matrix:
     for val in row:
         max_val = max(max_val, val)
 print(f"最大値: {max_val}")
+```
 </figure>
 
 ## 4.5 文字列入力を扱おう


### PR DESCRIPTION
- 第4章: 図4-11/4-12/4-13 内のコードフェンス未クローズを修正し、すべて<figure>としてレンダリング\n- 第5章: 図5-4 を<figure class="pseudocode">で図化（段階説明＋演算子メモ）\n- 第6章: 図6-3（二次元リスト）を<figure>に包み、テーブル＋コード例を図として整理\n\n公開確認後、図が<pre>内に入らないことと表示体裁の安定を確認予定