### PR TITLE
Content: パターン→実例マッピング（第4〜8章に展開）

### DIFF
--- a/src/chapter-abc-problems/index.md
+++ b/src/chapter-abc-problems/index.md
@@ -881,3 +881,12 @@ A問題とB問題の解法を理解したところで、実際のコンテスト
 {% endcapture %}
 {% include panel.html type="warn" title="⚠️ よくある誤り" content=abc_wrong %}
 
+
+{% capture ch7_map %}
+| パターン | 問題 | 難易度 | 制約目安 | 想定テク |
+|---|---|---|---|---|
+| A: 四則/条件/文字列 | [ABC086A](https://atcoder.jp/contests/abc086/tasks/abc086_a), [ABC081A](https://atcoder.jp/contests/abc081/tasks/abc081_a) | A | 小 | 偶奇/`count` |
+| A→Bの橋渡し | [ABC081B](https://atcoder.jp/contests/abc081/tasks/abc081_b), [ABC088B](https://atcoder.jp/contests/abc088/tasks/abc088_b) | B | 中 | 反復/ソート |
+| B: 2D/累積/組合せ | [ABC075B](https://atcoder.jp/contests/abc075/tasks/abc075_b), [ABC051B](https://atcoder.jp/contests/abc051/tasks/abc051_b) | B | 中 | グリッド/全探索 |
+{% endcapture %}
+{% include panel.html type="info" title="🔗 パターン→実例マッピング（ABC A/B）" content=ch7_map %}

--- a/src/chapter-basic-algorithms/index.md
+++ b/src/chapter-basic-algorithms/index.md
@@ -788,3 +788,16 @@ print(max_meetings(meetings))</code></pre>
 4. **貪欲に選択して大丈夫か？** → 局所最適＝全体最適の保証
 
 この判断力は、実際に多くの問題を解くことで身についてくる。次の章では、これらのアルゴリズムをより効率的に実行するための「データ構造」について学ぼう。適切なデータ構造を選ぶことで、同じアルゴリズムでも劇的に高速化できるんだ！
+
+{% capture ch5_map %}
+| パターン | 問題 | 難易度 | 制約目安 | 想定テク |
+|---|---|---|---|---|
+| 全探索（二重/三重） | [ABC051B Sum of Three Integers](https://atcoder.jp/contests/abc051/tasks/abc051_b) | B | 中 | 三重ループと枝刈り |
+| 条件分岐の整理 | [ABC086A Product](https://atcoder.jp/contests/abc086/tasks/abc086_a) | A | 小 | 場合分け/偶奇 |
+| 数学/GCD | [ABC109C Skip](https://atcoder.jp/contests/abc109/tasks/abc109_c) | C（発展） | 中 | 差分のGCD |
+| 文字列処理 | [ABC071B Not Found](https://atcoder.jp/contests/abc071/tasks/abc071_b) | B | 中 | 出現チェック/最小文字 |
+| ソート活用 | [ABC088B Card Game for Two](https://atcoder.jp/contests/abc088/tasks/abc088_b) | B | 小 | 降順ソートと交互取り |
+| 貪欲 | [ABC095B Bitter Alchemy](https://atcoder.jp/contests/abc095/tasks/abc095_b) | B | 小 | 最小コスト選択/余り処理 |
+| 貪欲（発展） | [ABC153C Fennec vs Monster](https://atcoder.jp/contests/abc153/tasks/abc153_c) | C（発展） | 中 | 降順ソート→上位Kカット |
+{% endcapture %}
+{% include panel.html type="info" title="🔗 パターン→実例マッピング（アルゴリズム）" content=ch5_map %}

--- a/src/chapter-basic-data-structures/index.md
+++ b/src/chapter-basic-data-structures/index.md
@@ -755,3 +755,14 @@ A4. スタック: `list.append/pop`、キュー: `collections.deque`
 A5. `collections.defaultdict(int)` または `dict.get(key, 0)` を用いる
 {% endcapture %}
 {% include panel.html type="info" title="📝 解答とヒント" content=ch6_quiz_a %}
+
+{% capture ch6_map %}
+| データ構造 | 問題 | 難易度 | 制約目安 | 想定テク |
+|---|---|---|---|---|
+| リスト操作 | [ABC081B Shift only](https://atcoder.jp/contests/abc081/tasks/abc081_b) | B | 中 | 反復/最小回数 |
+| 集合（重複排除） | [ABC085B Kagami Mochi](https://atcoder.jp/contests/abc085/tasks/abc085_b) | B | 小 | `set`で重複除去 |
+| ソート＋配列 | [ABC088B Card Game for Two](https://atcoder.jp/contests/abc088/tasks/abc088_b) | B | 小 | 降順ソート |
+| 辞書/頻度（発展） | [ABC081C Not so Diverse](https://atcoder.jp/contests/abc081/tasks/abc081_c) | C（発展） | 中 | 頻度マップ/整列 |
+| キュー/BFS（発展） | [ABC007C 幅優先探索](https://atcoder.jp/contests/abc007/tasks/abc007_3) | C（発展） | 中 | `deque`とBFS |
+{% endcapture %}
+{% include panel.html type="info" title="🔗 パターン→実例マッピング（データ構造）" content=ch6_map %}

--- a/src/chapter-input-output/index.md
+++ b/src/chapter-input-output/index.md
@@ -709,3 +709,16 @@ A4. `for _ in range(N): x = int(input())` のように N 回 `input()` を呼ぶ
 A5. `print(f"{x:.2f}")`（フォーマット指定: `.2f`）
 {% endcapture %}
 {% include panel.html type="info" title="📝 解答とヒント" content=quiz_a %}
+
+{% capture ch4_map %}
+| パターン | 問題 | 難易度 | 制約目安 | 想定テク |
+|---|---|---|---|---|
+| 1行で複数整数 | [ABC086A Product](https://atcoder.jp/contests/abc086/tasks/abc086_a) | A | 小 | `map(int, input().split())` |
+| N個の整数（1行） | [ABC081B Shift only](https://atcoder.jp/contests/abc081/tasks/abc081_b) | B | 中 | 分割→`map`→反復/条件 |
+| N行入力（整数） | [ABC155B Papers, Please](https://atcoder.jp/contests/abc155/tasks/abc155_b) | B | 中 | `for _ in range(N): int(input())` |
+| 2次元グリッド | [ABC075B Minesweeper](https://atcoder.jp/contests/abc075/tasks/abc075_b) | B | 中 | `H,W`→`grid=[input() for _ in range(H)]` |
+| 2次元数値 | [ABC237B Matrix Transposition](https://atcoder.jp/contests/abc237/tasks/abc237_b) | B | 中 | `H,W`＋各行`map(int, ...)` |
+| 文字列入力/処理 | [ABC081A Placing Marbles](https://atcoder.jp/contests/abc081/tasks/abc081_a) | A | 小 | `s=input(); s.count('1')` |
+| 混在データ | [ABC086C Traveling](https://atcoder.jp/contests/abc086/tasks/abc086_c) | C（発展） | 中 | 複数行/複数値の読解と検証 |
+{% endcapture %}
+{% include panel.html type="info" title="🔗 パターン→実例マッピング（入出力）" content=ch4_map %}

--- a/src/chapter-problem-solving/index.md
+++ b/src/chapter-problem-solving/index.md
@@ -875,3 +875,13 @@ A4. まず再現、最小ケースへ切り詰める、入力/状態を観察
 A5. 境界/最小/最大/ランダム/反例を含む、失敗時に原因が分かる
 {% endcapture %}
 {% include panel.html type="info" title="📝 解答とヒント" content=ch8_quiz_a %}
+
+{% capture ch8_map %}
+| 練習テーマ | 問題 | 難易度 | 制約目安 | 想定テク/プロセス |
+|---|---|---|---|---|
+| 読解→実装（基礎） | [ABC086A Product](https://atcoder.jp/contests/abc086/tasks/abc086_a) | A | 小 | Stage1-3で読解→実装→検証 |
+| サンプル分析→一般化 | [ABC081B Shift only](https://atcoder.jp/contests/abc081/tasks/abc081_b) | B | 中 | 反復・エッジ想定 |
+| 2D入力の設計 | [ABC075B Minesweeper](https://atcoder.jp/contests/abc075/tasks/abc075_b) | B | 中 | グリッド走査・境界条件 |
+| 数学設計（発展） | [ABC109C Skip](https://atcoder.jp/contests/abc109/tasks/abc109_c) | C | 中 | 差分GCD・証明的思考 |
+{% endcapture %}
+{% include panel.html type="info" title="🔗 パターン→実例マッピング（問題解決プロセス）" content=ch8_map %}


### PR DESCRIPTION
- 各パターンに対し 2〜3 問のAtCoder実例リンクを追補（難易度/制約目安/想定テク付）\n- 対象: 第4章（入出力）/第5章（アルゴリズム）/第6章（データ構造）/第7章（ABC）/第8章（問題解決プロセス）\n- panel表示でモバイル/ダークでも可読\n