### PR TITLE
Fix public 404s: add search.css; remove missing icon links

### DIFF
--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -23,8 +23,10 @@
     <link rel="stylesheet" href="{{ '/assets/css/search.css' | relative_url }}">
     
     <!-- Favicon -->
-    <link rel="icon" type="image/x-icon" href="{{ '/assets/favicon.ico' | relative_url }}">
-    <link rel="apple-touch-icon" href="{{ '/assets/apple-touch-icon.png' | relative_url }}">
+    {%- comment -%} Optional icons (omit if files are not present)
+    <!-- {%- comment -%} Optional icons omitted if file not present {%- endcomment -%} -->
+    <!--  -->
+    {%- endcomment -%}
     
     {%- comment -%} jekyll-seo-tag outputs Open Graph, Twitter, canonical, etc. {%- endcomment -%}
     

--- a/assets/css/search.css
+++ b/assets/css/search.css
@@ -1,0 +1,21 @@
+/* Lightweight search-specific styles (safe to load optionally) */
+.search-container { position: relative; }
+.search-input { width: 100%; box-sizing: border-box; }
+.search-results {
+  position: absolute;
+  top: 100%;
+  left: 0; right: 0;
+  margin-top: 0.5rem;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: var(--shadow-lg);
+  max-height: 400px;
+  overflow-y: auto;
+  display: none;
+}
+.search-results.active { display: block; }
+.search-results .result-item { padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border-color); }
+.search-results .result-item:last-child { border-bottom: none; }
+.search-results .result-title { font-weight: 600; color: var(--text-primary); }
+.search-results .result-snippet { font-size: 0.875rem; color: var(--text-secondary); }


### PR DESCRIPTION
Fixes repeated 404s on Pages:
- Adds assets/css/search.css referenced by layout and search.js
- Removes links to missing assets/apple-touch-icon.png and assets/favicon.ico (can be re-added later with files)

This avoids noise in link-check and ensures cleaner page loads.